### PR TITLE
Erstelle MCI-Ordner in Pytest-Buildout

### DIFF
--- a/.github/workflows/pytest_buildout.yml
+++ b/.github/workflows/pytest_buildout.yml
@@ -90,6 +90,10 @@ jobs:
         sudo mkdir -p /u01/app/claimx/temp/
         sudo mkdir -p /u01/app/claimx/import/importfiles/wsgi/
         sudo chmod -R 777 /u01
+    - name: Add MCI directories
+      run: |
+        sudo mkdir -p /u01/app/claimxmci/
+        sudo chmod -R 777 /u01
     - name: Install needed software
       run: |
         sudo apt-get update


### PR DESCRIPTION
Um die MCI-Tests in GitHub Actions ausführen zu können, muss ein neuer Pfad angelegt werden. Zurzeit laufen sowohl ClaimX als auch MCI gegen denselben Workflow, da die Anforderungen fast identisch sind.
Eventuell wäre es trotzdem hilfreich, die Workflows zu splitten, um eine bessere Übersicht über die Anforderungen der jeweiligen Projekte zu haben.