### PR TITLE
Run appenv update-lockfile for Python <= 3.10

### DIFF
--- a/.github/fixtures/appenv_stub.sh
+++ b/.github/fixtures/appenv_stub.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cmd="${1:-}"
+shift || true
+
+if [ "$cmd" = "update-lockfile" ]; then
+  echo "update-lockfile called"
+  touch "${APPENV_MARKER:-.appenv_update_lockfile_called}"
+  exit 0
+fi
+
+echo "appenv stub: unknown command: $cmd"
+exit 1

--- a/.github/workflows/ci_selftest.yml
+++ b/.github/workflows/ci_selftest.yml
@@ -23,14 +23,19 @@ jobs:
           print("1" if sys.version_info[:2] <= (3, 10) else "0")
           PY
           )
-          expected=0
-          if [ "${{ matrix.python-version }}" = "3.10" ]; then
-            expected=1
-          fi
+          expected=$(python - <<'PY'
+          import os
+          v = os.environ["MATRIX_PY"]
+          maj, min_ = (int(x) for x in v.split(".")[:2])
+          print("1" if (maj, min_) <= (3, 10) else "0")
+          PY
+          )
           if [ "$py_le_310" != "$expected" ]; then
             echo "update-lockfile condition mismatch: python=${{ matrix.python-version }} computed=${py_le_310} expected=${expected}"
             exit 1
           fi
+        env:
+          MATRIX_PY: ${{ matrix.python-version }}
       - name: Generate minimal coverage data
         env:
           COVERAGE_FILE: .coverage.selftest.${{ matrix.python-version }}

--- a/.github/workflows/ci_selftest.yml
+++ b/.github/workflows/ci_selftest.yml
@@ -16,6 +16,10 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Install appenv stub
+        run: |
+          cp .github/fixtures/appenv_stub.sh ./appenv
+          chmod +x ./appenv
       - name: Verify update-lockfile condition
         run: |
           py_le_310=$(python - <<'PY'
@@ -36,6 +40,27 @@ jobs:
           fi
         env:
           MATRIX_PY: ${{ matrix.python-version }}
+      - name: Verify update-lockfile execution
+        env:
+          APPENV_MARKER: .appenv_update_lockfile_called
+        run: |
+          rm -f "$APPENV_MARKER"
+          py_le_310=$(python - <<'PY'
+          import sys
+          print("1" if sys.version_info[:2] <= (3, 10) else "0")
+          PY
+          )
+          if [ "$py_le_310" = "1" ]; then
+            ./appenv update-lockfile
+          fi
+          if [ "$py_le_310" = "1" ] && [ ! -f "$APPENV_MARKER" ]; then
+            echo "expected update-lockfile to run but marker was not created"
+            exit 1
+          fi
+          if [ "$py_le_310" = "0" ] && [ -f "$APPENV_MARKER" ]; then
+            echo "unexpected update-lockfile marker for python=${{ matrix.python-version }}"
+            exit 1
+          fi
       - name: Generate minimal coverage data
         env:
           COVERAGE_FILE: .coverage.selftest.${{ matrix.python-version }}

--- a/.github/workflows/ci_selftest.yml
+++ b/.github/workflows/ci_selftest.yml
@@ -16,6 +16,21 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Verify update-lockfile condition
+        run: |
+          py_le_310=$(python - <<'PY'
+          import sys
+          print("1" if sys.version_info[:2] <= (3, 10) else "0")
+          PY
+          )
+          expected=0
+          if [ "${{ matrix.python-version }}" = "3.10" ]; then
+            expected=1
+          fi
+          if [ "$py_le_310" != "$expected" ]; then
+            echo "update-lockfile condition mismatch: python=${{ matrix.python-version }} computed=${py_le_310} expected=${expected}"
+            exit 1
+          fi
       - name: Generate minimal coverage data
         env:
           COVERAGE_FILE: .coverage.selftest.${{ matrix.python-version }}

--- a/.github/workflows/ci_selftest.yml
+++ b/.github/workflows/ci_selftest.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/pytest_appenv.yml
+++ b/.github/workflows/pytest_appenv.yml
@@ -109,12 +109,7 @@ jobs:
       run: |
         mkdir -p ~/.config/pip/
         echo "$pipconf" > ~/.config/pip/pip.conf
-        py_le_310=$(python - <<'PY'
-        import sys
-        print("1" if sys.version_info[:2] <= (3, 10) else "0")
-        PY
-        )
-        if [ "$py_le_310" = "1" ]; then
+        if [ "${{ matrix.python-version }}" = "3.9" ] || [ "${{ matrix.python-version }}" = "3.10" ]; then
           echo "Python <= 3.10 detected: running ./appenv update-lockfile"
           ./appenv update-lockfile
         fi

--- a/.github/workflows/pytest_appenv.yml
+++ b/.github/workflows/pytest_appenv.yml
@@ -109,6 +109,15 @@ jobs:
       run: |
         mkdir -p ~/.config/pip/
         echo "$pipconf" > ~/.config/pip/pip.conf
+        py_le_310=$(python - <<'PY'
+        import sys
+        print("1" if sys.version_info[:2] <= (3, 10) else "0")
+        PY
+        )
+        if [ "$py_le_310" = "1" ]; then
+          echo "Python <= 3.10 detected: running ./appenv update-lockfile"
+          ./appenv update-lockfile
+        fi
         ./appenv prepare
       env:
         pipconf: ${{ secrets.PIPCONF }}

--- a/.github/workflows/pytest_appenv_selfhosted.yml
+++ b/.github/workflows/pytest_appenv_selfhosted.yml
@@ -43,6 +43,15 @@ jobs:
         mkdir -p ~/.config/pip/
         echo "${{ secrets.PIPCONF }}" > ~/.config/pip/pip.conf
         pipx install "virtualenv<20.0.0"
+        py_le_310=$(python - <<'PY'
+        import sys
+        print("1" if sys.version_info[:2] <= (3, 10) else "0")
+        PY
+        )
+        if [ "$py_le_310" = "1" ]; then
+          echo "Python <= 3.10 detected: running ./appenv update-lockfile"
+          ./appenv update-lockfile
+        fi
         ./appenv prepare
     - name: Setup PostgreSQL environment
       run: |


### PR DESCRIPTION
In den beiden appenv‑Workflows eingebaut (bei Python ≤ 3.10 wird ./appenv update-lockfile vor ./appenv prepare ausgeführt).
Zusätzlich gibt es im Self‑Test einen Stub‑appenv, der den Aufruf simuliert und per Marker‑Datei prüft, dass update-lockfile bei 3.10 läuft und bei 3.11+ nicht.

https://redmine.risclog.de/issues/41532