### PR TITLE
Allow configurable Python version for coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -6,6 +6,11 @@ on:
       min_coverage:
         required: true
         type: number
+      python_version:
+        default: '3.9'
+        required: false
+        type: string
+
 
 jobs:
   coverage:
@@ -14,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: ${{ inputs.python_version }}
       - run: python -m pip install --upgrade coverage[toml]
       - uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
```
Run if ls .coverage.* 1>/dev/null 2>&1; then
Combined data file .coverage.3.12
Couldn't parse 'src/risclog/vwfsservice/api/claim.py' as Python source: 'invalid syntax' at line 44
Error: Process completed with exit code 1.
```

Hatte den Fehler wenn man Python Syntax, die nur ab 3.12 erlaubt, ist verwendet. Mit dem Parameter konnte ich das beheben. Da der default immernoch 3.9 ist, sollten keine bestehenden Workflows kaputt gehen